### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -80,10 +80,11 @@ def _log_save_operation(users, config_file):
 
 
 def _log_debug_data(save_data):
-    """Log debug information about the data being saved"""
-    print_log("🔍 DEBUG: Exact JSON being written:", bcolors.HEADER, debug_only=True)
-    print_log(json.dumps(save_data, indent=2), bcolors.OKCYAN, debug_only=True)
-
+    """Log debug information about the data being saved (redacted)."""
+    from .utils import redact_sensitive
+    import json
+    print_log("🔍 DEBUG: Exact JSON being written (redacted):", bcolors.HEADER, debug_only=True)
+    print_log(json.dumps(redact_sensitive(save_data), indent=2), bcolors.OKCYAN, debug_only=True)
 
 def _verify_saved_data(config_file):
     """Verify that the data was saved correctly"""


### PR DESCRIPTION
Potential fix for [https://github.com/realAbitbol/twitch_colorchanger/security/code-scanning/2](https://github.com/realAbitbol/twitch_colorchanger/security/code-scanning/2)

The problem is the possibility of logging sensitive data (especially `client_secret`) in cleartext via `print_log` or any other logging function that can be called with the entire user config or related objects containing secrets.

**General Fix:**  
- Implement central redaction: sanitize loggable data before printing.
- Specifically, before logging dictionaries (e.g., user config), redact or remove values of sensitive fields (`client_secret`, `access_token`, `refresh_token`).
- Implement a helper function for redacting sensitive fields in user objects or config dicts before converting them to strings for logging.
- Apply this redaction in:
  - The logger utility (`print_log`) such that dictionary arguments are automatically redacted.
  - High-risk spots such as update/save/logging routines in config management code, where full config dicts may be logged.

**Implementation Steps:**  
- In `src/utils.py`, create a function `redact_sensitive` that recursively redacts the values of known sensitive fields from dicts for logging.
- Update `print_log` such that if its `message` is a dict (or list of dicts), it logs the redacted version.
- In `src/config.py`, update any spot that calls `print_log` with a dict, e.g., user config, to ensure it always passes the redacted version.
- Prioritize central handling so individual log calls do not need to manually redact--but also apply targeted redaction where potentially missed.

No new package imports are required; redact logic can be implemented via pure Python.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
