### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -75,14 +75,18 @@ def _set_file_permissions(config_file):
 def _log_save_operation(users, config_file):
     """Log the save operation details"""
     print_log(f"💾 Saving {len(users)} users to {config_file}", bcolors.OKBLUE, debug_only=True)
+    from .utils import sanitize_for_log
     for i, user in enumerate(users, 1):
-        print_log(f"  User {i}: {user['username']} -> is_prime_or_turbo: {user.get('is_prime_or_turbo', 'MISSING_FIELD')}", bcolors.OKCYAN, debug_only=True)
-
+        safe_user = sanitize_for_log({"username": user.get('username'), "is_prime_or_turbo": user.get('is_prime_or_turbo', 'MISSING_FIELD')})
+        print_log(f"  User {i}: {safe_user['username']} -> is_prime_or_turbo: {safe_user.get('is_prime_or_turbo', 'MISSING_FIELD')}", bcolors.OKCYAN, debug_only=True)
 
 def _log_debug_data(save_data):
     """Log debug information about the data being saved"""
+    from .utils import sanitize_for_log
     print_log("🔍 DEBUG: Exact JSON being written:", bcolors.HEADER, debug_only=True)
-    print_log(json.dumps(save_data, indent=2), bcolors.OKCYAN, debug_only=True)
+    safe_data = sanitize_for_log(save_data)
+    import json
+    print_log(json.dumps(safe_data, indent=2), bcolors.OKCYAN, debug_only=True)
 
 
 def _verify_saved_data(config_file):


### PR DESCRIPTION
Potential fix for [https://github.com/realAbitbol/twitch_colorchanger/security/code-scanning/1](https://github.com/realAbitbol/twitch_colorchanger/security/code-scanning/1)

The primary solution is to prevent logging of sensitive values (`client_secret`, `access_token`, `refresh_token`) in all cases, including in debug logs. Implement a function to sanitize/removes/obfuscates secrets from any objects (dicts) passed to the logger. This involves:

- Adding a utility, e.g., `sanitize_for_log(obj)`, in `src/utils.py` to replace sensitive fields with redacted markers when passed a dict or stringified dict.
- Updating calls in `src/utils.py` (e.g., in `print_log`) so that, if the message is a dict or list, sanitize it before converting it to a string for logging.
- All direct uses in `src/config.py` that log configuration/user objects (or lists thereof) must be wrapped with this sanitizer before logging.
- This fix will only change the printing methods, and how they're invoked, not the structure of the config files or user dicts.

Specific edits:
- Add the sanitization utility in `src/utils.py`.
- Update `print_log` in `src/utils.py` to automatically sanitize dict/list message values (especially when debug_only=True).
- In `src/config.py`, ensure that `_log_save_operation`, `_log_debug_data`, and any place where users/configs are logged pass through the sanitizer.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
