### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests and Coverage
+permissions:
+  contents: read
 
 on:
   push:
@@ -9,6 +11,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: write
     name: Python Tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/realAbitbol/twitch_colorchanger/security/code-scanning/10](https://github.com/realAbitbol/twitch_colorchanger/security/code-scanning/10)

To fix the issue, set a `permissions` block limiting the GITHUB_TOKEN scope to the least privileges required. For most jobs, including the `security` job flagged here, only `contents: read` is necessary, which allows jobs to fetch the contents of the repository but not to write changes. You should add the appropriate `permissions` block under each job that does not require escalated privileges—or, for convenience and to avoid repetition, at the workflow root if all jobs except one can inherit read-only access.

Here, to be precise:
- Add `permissions: contents: read` at the workflow (top/root) level to apply to all jobs by default.
- For the `test` job, which contains a "Commit coverage badge" step that pushes to the repo, override with `permissions: contents: write` to permit necessary git pushes.

No other jobs require more than read access.

**Required changes:**
- Insert `permissions: contents: read` at the root, after the workflow `name` and before `on`.
- Add `permissions: contents: write` at the top of the `test` job definition (before `name:` in that job).

No extra dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
